### PR TITLE
Fix: References after move to @ergebnis

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/classy
+ * @see https://github.com/ergebnis/classy
  */
 
 use Ergebnis\PhpCsFixer\Config;
@@ -19,7 +19,7 @@ Copyright (c) 2017 Andreas Möller
 For the full copyright and license information, please view
 the LICENSE file that was distributed with this source code.
 
-@see https://github.com/localheinz/classy
+@see https://github.com/ergebnis/classy
 EOF;
 
 $config = Config\Factory::fromRuleSet(new Config\RuleSet\Php71($header));

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`0.4.0...master`](https://github.com/localheinz/classy/compare/0.4.0...master).
+For a full diff see [`0.4.0...master`](https://github.com/ergebnis/classy/compare/0.4.0...master).
 
 ### Fixed
 
-* Dropped support for PHP 7.1 ([#9000](https://github.com/localheinz/classy/pull/9000)), by [@localheinz](https://github.com/localheinz)
+* Dropped support for PHP 7.1 ([#9000](https://github.com/ergebnis/classy/pull/9000)), by [@localheinz](https://github.com/localheinz)

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # classy
 
-[![CI Status](https://github.com/localheinz/classy/workflows/Continuous%20Integration/badge.svg)](https://github.com/localheinz/classy/actions)
-[![codecov](https://codecov.io/gh/localheinz/classy/branch/master/graph/badge.svg)](https://codecov.io/gh/localheinz/classy)
-[![Latest Stable Version](https://poser.pugx.org/localheinz/classy/v/stable)](https://packagist.org/packages/localheinz/classy)
-[![Total Downloads](https://poser.pugx.org/localheinz/classy/downloads)](https://packagist.org/packages/localheinz/classy)
+[![CI Status](https://github.com/ergebnis/classy/workflows/Continuous%20Integration/badge.svg)](https://github.com/ergebnis/classy/actions)
+[![codecov](https://codecov.io/gh/ergebnis/classy/branch/master/graph/badge.svg)](https://codecov.io/gh/ergebnis/classy)
+[![Latest Stable Version](https://poser.pugx.org/ergebnis/classy/v/stable)](https://packagist.org/packages/ergebnis/classy)
+[![Total Downloads](https://poser.pugx.org/ergebnis/classy/downloads)](https://packagist.org/packages/ergebnis/classy)
 
 Provides a finder for classy elements.
 
@@ -12,7 +12,7 @@ Provides a finder for classy elements.
 Run
 
 ```
-$ composer require localheinz/classy
+$ composer require ergebnis/classy
 ```
 
 

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
-  "name": "localheinz/classy",
+  "name": "ergebnis/classy",
   "type": "library",
   "description": "Provides a way to collect classy constructs from source or a directory.",
-  "homepage": "https://github.com/localheinz/classy",
+  "homepage": "https://github.com/ergebnis/classy",
   "license": "MIT",
   "authors": [
     {
@@ -41,7 +41,7 @@
     }
   },
   "support": {
-    "issues": "https://github.com/localheinz/classy/issues",
-    "source": "https://github.com/localheinz/classy"
+    "issues": "https://github.com/ergebnis/classy/issues",
+    "source": "https://github.com/ergebnis/classy"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0078ea6eb42c37624db24f4845a99fa2",
+    "content-hash": "0306c075f7547ac3fe049c52accc8ded",
     "packages": [],
     "packages-dev": [
         {

--- a/src/Construct.php
+++ b/src/Construct.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/classy
+ * @see https://github.com/ergebnis/classy
  */
 
 namespace Localheinz\Classy;

--- a/src/Constructs.php
+++ b/src/Constructs.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/classy
+ * @see https://github.com/ergebnis/classy
  */
 
 namespace Localheinz\Classy;

--- a/src/Exception/DirectoryDoesNotExist.php
+++ b/src/Exception/DirectoryDoesNotExist.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/classy
+ * @see https://github.com/ergebnis/classy
  */
 
 namespace Localheinz\Classy\Exception;

--- a/src/Exception/ExceptionInterface.php
+++ b/src/Exception/ExceptionInterface.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/classy
+ * @see https://github.com/ergebnis/classy
  */
 
 namespace Localheinz\Classy\Exception;

--- a/src/Exception/MultipleDefinitionsFound.php
+++ b/src/Exception/MultipleDefinitionsFound.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/classy
+ * @see https://github.com/ergebnis/classy
  */
 
 namespace Localheinz\Classy\Exception;

--- a/src/Exception/ParseError.php
+++ b/src/Exception/ParseError.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/classy
+ * @see https://github.com/ergebnis/classy
  */
 
 namespace Localheinz\Classy\Exception;

--- a/test/AutoReview/SrcCodeTest.php
+++ b/test/AutoReview/SrcCodeTest.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/classy
+ * @see https://github.com/ergebnis/classy
  */
 
 namespace Localheinz\Classy\Test\AutoReview;

--- a/test/Bench/ClassyBench.php
+++ b/test/Bench/ClassyBench.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/classy
+ * @see https://github.com/ergebnis/classy
  */
 
 namespace Localheinz\Classy\Test\Bench;

--- a/test/Unit/ConstructTest.php
+++ b/test/Unit/ConstructTest.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/classy
+ * @see https://github.com/ergebnis/classy
  */
 
 namespace Localheinz\Classy\Test\Unit;

--- a/test/Unit/ConstructsTest.php
+++ b/test/Unit/ConstructsTest.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/classy
+ * @see https://github.com/ergebnis/classy
  */
 
 namespace Localheinz\Classy\Test\Unit;

--- a/test/Unit/Exception/AbstractTestCase.php
+++ b/test/Unit/Exception/AbstractTestCase.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/classy
+ * @see https://github.com/ergebnis/classy
  */
 
 namespace Localheinz\Classy\Test\Unit\Exception;

--- a/test/Unit/Exception/DirectoryDoesNotExistTest.php
+++ b/test/Unit/Exception/DirectoryDoesNotExistTest.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/classy
+ * @see https://github.com/ergebnis/classy
  */
 
 namespace Localheinz\Classy\Test\Unit\Exception;

--- a/test/Unit/Exception/MultipleDefinitionsFoundTest.php
+++ b/test/Unit/Exception/MultipleDefinitionsFoundTest.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/classy
+ * @see https://github.com/ergebnis/classy
  */
 
 namespace Localheinz\Classy\Test\Unit\Exception;

--- a/test/Unit/Exception/ParseErrorTest.php
+++ b/test/Unit/Exception/ParseErrorTest.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/classy
+ * @see https://github.com/ergebnis/classy
  */
 
 namespace Localheinz\Classy\Test\Unit\Exception;


### PR DESCRIPTION
This PR

* [x] fixes references after the move to @ergebnis