### PR TITLE
Fix: Require phpstan/extension-installer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     "localheinz/phpstan-rules": "~0.13.0",
     "localheinz/test-util": "0.2.2",
     "phpbench/phpbench": "~0.16.10",
+    "phpstan/extension-installer": "^1.0.3",
     "phpstan/phpstan": "~0.11.19",
     "phpstan/phpstan-deprecation-rules": "~0.11.2",
     "phpstan/phpstan-strict-rules": "~0.11.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ddf870a9a5c85c9d0011b81bb70c4d19",
+    "content-hash": "a16ec661eaac54fa31e5cdeffad472c8",
     "packages": [],
     "packages-dev": [
         {
@@ -1145,6 +1145,7 @@
                 "phpunit",
                 "test"
             ],
+            "abandoned": "ergebnis/test-util",
             "time": "2017-10-02T11:49:14+00:00"
         },
         {
@@ -2539,6 +2540,50 @@
                 "stub"
             ],
             "time": "2019-10-03T11:07:50+00:00"
+        },
+        {
+            "name": "phpstan/extension-installer",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/extension-installer.git",
+                "reference": "295656793c53b5eb73a38486032ad1bd650264bc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/extension-installer/zipball/295656793c53b5eb73a38486032ad1bd650264bc",
+                "reference": "295656793c53b5eb73a38486032ad1bd650264bc",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.1",
+                "php": "^7.1",
+                "phpstan/phpstan": ">=0.11.6"
+            },
+            "require-dev": {
+                "composer/composer": "^1.8",
+                "consistence/coding-standard": "^3.8",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
+                "jakub-onderka/php-parallel-lint": "^1.0",
+                "phing/phing": "^2.16",
+                "phpstan/phpstan-strict-rules": "^0.11",
+                "slevomat/coding-standard": "^5.0.4"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PHPStan\\ExtensionInstaller\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\ExtensionInstaller\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Composer plugin for automatic installation of PHPStan extensions",
+            "time": "2019-10-18T17:09:48+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,8 +3,8 @@ includes:
 
 parameters:
 	classesAllowedToBeExtended:
+		- Ergebnis\Classy\Test\Unit\Exception\AbstractTestCase
 		- InvalidArgumentException
-		- Localheinz\Classy\Test\Unit\Exception\AbstractTestCase
 		- ParseError
 		- RuntimeException
 	excludes_analyse:


### PR DESCRIPTION
This PR

* [x] requires `phpstan/extension-installer`
* [x] fixes an incorrect class name reference

Follows #93.