### PR TITLE
Fix: Replace localheinz/classy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,36 @@ For a full diff see [`0.4.0...0.5.0`][0.4.0...0.5.0].
 
 * Renamed vendor namespace `Localheinz` to `Ergebnis` after move to [@ergebnis] ([#88]), by [@localheinz]
 
+  Run
+
+  ```
+  $ composer remove localheinz/classy
+  ```
+
+  and
+
+  ```
+  $ composer require ergebnis/classy
+  ```
+
+  to update.
+
+  Run
+
+  ```
+  $ find . -type f -exec sed -i '.bak' 's/Localheinz\\Classy/Ergebnis\\Classy/g' {} \;
+  ```
+
+  to replace occurrences of `Localheinz\Classy` with `Ergebnis\Classy`.
+
+  Run
+
+  ```
+  $ find -type f -name '*.bak' -delete
+  ```
+
+  to delete backup files created in the previous step.
+
 ### Fixed
 
 * Dropped support for PHP 7.1 ([#77]), by [@localheinz]

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,9 @@
     "php": "^7.2",
     "ext-tokenizer": "*"
   },
+  "replace": {
+    "localheinz/classy": "*"
+  },
   "require-dev": {
     "ergebnis/php-cs-fixer-config": "~1.1.0",
     "infection/infection": "~0.15.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a16ec661eaac54fa31e5cdeffad472c8",
+    "content-hash": "03b77db789e3958a65958626fc3fc8db",
     "packages": [],
     "packages-dev": [
         {
@@ -1034,6 +1034,7 @@
                 "json",
                 "printer"
             ],
+            "abandoned": "ergebnis/json-printer",
             "time": "2018-08-11T23:54:50+00:00"
         },
         {


### PR DESCRIPTION
This PR

* [x] replaces `localheinz/classy` and adds instructions how to do so