### PR TITLE
Fix: Remove inappropriate replace configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`0.5.0...master`][0.5.0...master].
+For a full diff see [`0.5.1...master`][0.5.1...master].
+
+## [`0.5.1`][0.5.1]
+
+For a full diff see [`0.5.0...0.5.1`][0.5.0...0.5.1].
+
+### Fixed
+
+* Removed an inappropriate `replace` configuration from `composer.json` ([#100]), by [@localheinz]
 
 ## [`0.5.0`][0.5.0]
 
@@ -51,12 +59,15 @@ For a full diff see [`0.4.0...0.5.0`][0.4.0...0.5.0].
 * Dropped support for PHP 7.1 ([#77]), by [@localheinz]
 
 [0.5.0]: https://github.com/localheinz/ergebnis/classy/releases/tag/0.5.0
+[0.5.1]: https://github.com/localheinz/ergebnis/classy/releases/tag/0.5.0
 
 [0.4.0...0.5.0]: https://github.com/ergebnis/classy/compare/0.4.0...0.5.0
-[0.5.0...master]: https://github.com/ergebnis/classy/compare/0.5.0...master
+[0.5.0...0.5.1]: https://github.com/ergebnis/classy/compare/0.5.0...0.5.1
+[0.5.1...master]: https://github.com/ergebnis/classy/compare/0.5.1...master
 
 [#77]: https://github.com/ergebnis/classy/pull/77
 [#88]: https://github.com/ergebnis/classy/pull/88
+[#100]: https://github.com/ergebnis/classy/pull/100
 
 [@ergebnis]: https://github.com/ergebnis
 [@localheinz]: https://github.com/localheinz

--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,6 @@
     "php": "^7.2",
     "ext-tokenizer": "*"
   },
-  "replace": {
-    "localheinz/classy": "*"
-  },
   "require-dev": {
     "ergebnis/php-cs-fixer-config": "~1.1.0",
     "ergebnis/phpstan-rules": "~0.14.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b950947237a5c665e85e7de466922e06",
+    "content-hash": "733edf39a95417bdd7a90a1b88331d3e",
     "packages": [],
     "packages-dev": [
         {


### PR DESCRIPTION
This PR

* [x] removes an inappropriate `replace` configuration from `composer.json`

Follows #88.