### PR TITLE
Enhancement: Use ergebnis/php-cs-fixer-config instead of localheinz/php-cs-fixer-config

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/classy
  */
 
-use Localheinz\PhpCsFixer\Config;
+use Ergebnis\PhpCsFixer\Config;
 
 $header = <<<'EOF'
 Copyright (c) 2017 Andreas Möller

--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,10 @@
   },
   "require-dev": {
     "ergebnis/composer-normalize": "^1.3.1",
+    "ergebnis/php-cs-fixer-config": "^1.1.2",
     "ergebnis/phpstan-rules": "~0.13.0",
     "ergebnis/test-util": "~0.7.0",
     "infection/infection": "~0.13.6",
-    "localheinz/php-cs-fixer-config": "~1.24.0",
     "phpbench/phpbench": "~0.16.10",
     "phpstan/extension-installer": "^1.0.3",
     "phpstan/phpstan": "~0.11.19",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "da49a43785335a5457a527d719066ab0",
+    "content-hash": "c62310d1e143032f1ef44cdf7b63759e",
     "packages": [],
     "packages-dev": [
         {
@@ -479,6 +479,56 @@
                 "plugin"
             ],
             "time": "2019-09-07T10:12:23+00:00"
+        },
+        {
+            "name": "ergebnis/php-cs-fixer-config",
+            "version": "1.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ergebnis/php-cs-fixer-config.git",
+                "reference": "cd964747d45e41509161828863e896a682563970"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ergebnis/php-cs-fixer-config/zipball/cd964747d45e41509161828863e896a682563970",
+                "reference": "cd964747d45e41509161828863e896a682563970",
+                "shasum": ""
+            },
+            "require": {
+                "friendsofphp/php-cs-fixer": "~2.16.0",
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "ergebnis/composer-normalize": "^1.3.1",
+                "ergebnis/phpstan-rules": "~0.13.0",
+                "ergebnis/test-util": "~0.9.1",
+                "infection/infection": "~0.13.6",
+                "jangregor/phpstan-prophecy": "~0.4.2",
+                "phpstan/extension-installer": "^1.0.3",
+                "phpstan/phpstan": "~0.11.19",
+                "phpstan/phpstan-deprecation-rules": "~0.11.2",
+                "phpstan/phpstan-strict-rules": "~0.11.1",
+                "phpunit/phpunit": "^7.5.18"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Ergebnis\\PhpCsFixer\\Config\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Andreas Möller",
+                    "email": "am@localheinz.com"
+                }
+            ],
+            "description": "Provides a configuration factory and multiple rule sets for friendsofphp/php-cs-fixer.",
+            "homepage": "https://github.com/ergebnis/php-cs-fixer-config",
+            "time": "2019-12-19T09:40:03+00:00"
         },
         {
             "name": "ergebnis/phpstan-rules",
@@ -1191,49 +1241,6 @@
             ],
             "abandoned": "ergebnis/json-printer",
             "time": "2018-08-11T23:54:50+00:00"
-        },
-        {
-            "name": "localheinz/php-cs-fixer-config",
-            "version": "1.24.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/localheinz/php-cs-fixer-config.git",
-                "reference": "6c43e1bfecf6079dd8bc5891fe8bfa6f303c87c1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/localheinz/php-cs-fixer-config/zipball/6c43e1bfecf6079dd8bc5891fe8bfa6f303c87c1",
-                "reference": "6c43e1bfecf6079dd8bc5891fe8bfa6f303c87c1",
-                "shasum": ""
-            },
-            "require": {
-                "friendsofphp/php-cs-fixer": "~2.16.0",
-                "php": "^7.1"
-            },
-            "require-dev": {
-                "localheinz/composer-normalize": "^1.3.1",
-                "phpunit/phpunit": "^7.5.17"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Localheinz\\PhpCsFixer\\Config\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Andreas Möller",
-                    "email": "am@localheinz.com"
-                }
-            ],
-            "description": "Provides a configuration factory and multiple rule sets for friendsofphp/php-cs-fixer.",
-            "homepage": "https://github.com/localheinz/php-cs-fixer-config",
-            "abandoned": "ergebnis/php-cs-fixer-config",
-            "time": "2019-11-03T18:42:30+00:00"
         },
         {
             "name": "lstrojny/functional-php",


### PR DESCRIPTION
This PR

* [x] uses [`ergebnis/php-cs-fixer-config`](https://github.com/ergebnis/php-cs-fixer-config) instead of [`localheinz/php-cs-fixer-config`](https://github.com/localheinz/php-cs-fixer-config)