### PR TITLE
Fix: Exclude fixtures from analysis with vimeo/psalm

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -18,6 +18,7 @@
         <directory name="src" />
         <directory name="test" />
         <ignoreFiles>
+            <directory name="test/Fixture" />
             <directory name="vendor" />
         </ignoreFiles>
     </projectFiles>


### PR DESCRIPTION
This PR

* [x] excludes fixtures from analysis with `vimeo/psalm`