### PR TITLE
Fix: Drop support for PHP 7.1

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -15,13 +15,10 @@ branches:
       required_status_checks:
         contexts:
           - "Code Coverage (7.4, locked)"
-          - "Coding Standards (7.1, locked)"
+          - "Coding Standards (7.2, locked)"
           - "Dependency Analysis (7.4, locked)"
           - "Mutation Tests (7.4, locked)"
           - "Static Code Analysis (7.4, locked)"
-          - "Tests (7.1, highest)"
-          - "Tests (7.1, locked)"
-          - "Tests (7.1, lowest)"
           - "Tests (7.2, highest)"
           - "Tests (7.2, locked)"
           - "Tests (7.2, lowest)"

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.1"
+          - "7.2"
 
         dependencies:
           - "locked"
@@ -204,7 +204,6 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.1"
           - "7.2"
           - "7.3"
           - "7.4"

--- a/.github/workflows/renew.yaml
+++ b/.github/workflows/renew.yaml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.1"
+          - "7.2"
 
         dependencies:
           - "locked"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`0.5.2...main`][0.5.2...main].
+For a full diff see [`0.5.3...main`][0.5.3...main].
+
+## [`0.5.3`][0.5.3]
+
+For a full diff see [`0.5.2...0.5.3`][0.5.2...0.5.3].
+
+### Changed
+
+* Dropped support for PHP 7.1 ([#231]), by [@localheinz]
 
 ## [`0.5.2`][0.5.2]
 
@@ -69,16 +77,19 @@ For a full diff see [`0.4.0...0.5.0`][0.4.0...0.5.0].
 [0.5.0]: https://github.com/localheinz/ergebnis/classy/releases/tag/0.5.0
 [0.5.1]: https://github.com/localheinz/ergebnis/classy/releases/tag/0.5.1
 [0.5.2]: https://github.com/localheinz/ergebnis/classy/releases/tag/0.5.2
+[0.5.3]: https://github.com/localheinz/ergebnis/classy/releases/tag/0.5.3
 
 [0.4.0...0.5.0]: https://github.com/ergebnis/classy/compare/0.4.0...0.5.0
 [0.5.0...0.5.1]: https://github.com/ergebnis/classy/compare/0.5.0...0.5.1
 [0.5.1...0.5.2]: https://github.com/ergebnis/classy/compare/0.5.1...0.5.2
-[0.5.2...main]: https://github.com/ergebnis/classy/compare/0.5.2...main
+[0.5.2...0.5.3]: https://github.com/ergebnis/classy/compare/0.5.2...0.5.3
+[0.5.3...main]: https://github.com/ergebnis/classy/compare/0.5.3...main
 
 [#77]: https://github.com/ergebnis/classy/pull/77
 [#88]: https://github.com/ergebnis/classy/pull/88
 [#100]: https://github.com/ergebnis/classy/pull/100
 [#103]: https://github.com/ergebnis/classy/pull/103
+[#231]: https://github.com/ergebnis/classy/pull/231
 
 [@ergebnis]: https://github.com/ergebnis
 [@localheinz]: https://github.com/localheinz

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     }
   ],
   "require": {
-    "php": "^7.1",
+    "php": "^7.2",
     "ext-tokenizer": "*"
   },
   "require-dev": {
@@ -40,7 +40,7 @@
   },
   "config": {
     "platform": {
-      "php": "7.1.33"
+      "php": "7.2.33"
     },
     "preferred-install": "dist",
     "sort-packages": true

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4b2e62f03d4627657b461f517763f28c",
+    "content-hash": "ccf90136b0481cf7c249f04fc1823689",
     "packages": [],
     "packages-dev": [
         {
@@ -5262,12 +5262,12 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.1",
+        "php": "^7.2",
         "ext-tokenizer": "*"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.1.33"
+        "php": "7.2.33"
     },
     "plugin-api-version": "1.1.0"
 }


### PR DESCRIPTION
This PR

* [x] drops support for PHP 7.1

Related to https://github.com/ergebnis/composer-normalize/issues/529.