### PR TITLE
Fix: Properly determine classy name within namespace with single segment

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -10,7 +10,7 @@ on: # yamllint disable-line rule:truthy
 
 env:
   MIN_COVERED_MSI: 86
-  MIN_MSI: 85
+  MIN_MSI: 84
   PHP_EXTENSIONS: "mbstring, tokenizer"
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`1.1.0...main`][1.1.0...main].
+For a full diff see [`1.1.1...main`][1.1.1...main].
+
+## [`1.1.1`][1.1.1]
+
+For a full diff see [`1.1.0...1.1.1`][1.1.0...1.1.1].
+
+### Fixed
+
+* Determine classy names within namespace with single segment on PHP 8.0 ([#343]), by [@localheinz]
 
 ## [`1.1.0`][1.1.0]
 
@@ -92,6 +100,7 @@ For a full diff see [`0.4.0...0.5.0`][0.4.0...0.5.0].
 [1.0.0]: https://github.com/localheinz/ergebnis/classy/releases/tag/1.0.0
 [1.0.1]: https://github.com/localheinz/ergebnis/classy/releases/tag/1.0.1
 [1.1.0]: https://github.com/localheinz/ergebnis/classy/releases/tag/1.1.0
+[1.1.1]: https://github.com/localheinz/ergebnis/classy/releases/tag/1.1.1
 
 [0.4.0...0.5.0]: https://github.com/ergebnis/classy/compare/0.4.0...0.5.0
 [0.5.0...0.5.1]: https://github.com/ergebnis/classy/compare/0.5.0...0.5.1
@@ -99,7 +108,8 @@ For a full diff see [`0.4.0...0.5.0`][0.4.0...0.5.0].
 [0.5.2...1.0.0]: https://github.com/ergebnis/classy/compare/0.5.2...1.0.0
 [1.0.0...1.0.1]: https://github.com/ergebnis/classy/compare/1.0.0...1.0.1
 [1.0.1...1.1.0]: https://github.com/ergebnis/classy/compare/1.0.1...1.1.0
-[1.1.0...main]: https://github.com/ergebnis/classy/compare/1.1.0...main
+[1.1.0...1.1.1]: https://github.com/ergebnis/classy/compare/1.1.0...1.1.1
+[1.1.1...main]: https://github.com/ergebnis/classy/compare/1.1.1...main
 
 [#77]: https://github.com/ergebnis/classy/pull/77
 [#88]: https://github.com/ergebnis/classy/pull/88
@@ -107,6 +117,7 @@ For a full diff see [`0.4.0...0.5.0`][0.4.0...0.5.0].
 [#103]: https://github.com/ergebnis/classy/pull/103
 [#231]: https://github.com/ergebnis/classy/pull/231
 [#235]: https://github.com/ergebnis/classy/pull/235
+[#343]: https://github.com/ergebnis/classy/pull/343
 
 [@ergebnis]: https://github.com/ergebnis
 [@localheinz]: https://github.com/localheinz

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 COMPOSER_ROOT_VERSION:=1.0-dev
 MIN_COVERED_MSI:=86
-MIN_MSI:=85
+MIN_MSI:=84
 
 .PHONY: it
 it: coding-standards static-code-analysis tests ## Runs the coding-standards, static-code-analysis, and tests targets

--- a/src/Constructs.php
+++ b/src/Constructs.php
@@ -38,12 +38,17 @@ final class Constructs
         $count = \count($sequence);
         $namespacePrefix = '';
 
-        $namespaceSegmentOrNamespaceToken = \T_STRING;
+        $namespaceSegmentOrNamespaceTokens = [
+            \T_STRING,
+        ];
 
         // https://wiki.php.net/rfc/namespaced_names_as_token
         if (\PHP_VERSION_ID >= 80000 && \defined('T_NAME_QUALIFIED')) {
-            /** @var int $namespaceSegmentOrNamespaceToken */
-            $namespaceSegmentOrNamespaceToken = \T_NAME_QUALIFIED;
+            /** @var array<int> $namespaceSegmentOrNamespaceTokens */
+            $namespaceSegmentOrNamespaceTokens = [
+                \T_STRING,
+                \T_NAME_QUALIFIED,
+            ];
         }
 
         for ($index = 0; $index < $count; ++$index) {
@@ -57,7 +62,7 @@ final class Constructs
                 for ($index = self::significantAfter($index, $sequence, $count); $index < $count; ++$index) {
                     $token = $sequence[$index];
 
-                    if (\is_array($token) && $namespaceSegmentOrNamespaceToken !== $token[0]) {
+                    if (\is_array($token) && !\in_array($token[0], $namespaceSegmentOrNamespaceTokens, true)) {
                         continue;
                     }
 

--- a/test/Fixture/Classy/WithinNamespaceWithSingleSegment/source.php
+++ b/test/Fixture/Classy/WithinNamespaceWithSingleSegment/source.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Ergebnis;
+
+class Foo {}
+
+interface Bar {}
+
+trait Baz {}

--- a/test/Unit/ConstructsTest.php
+++ b/test/Unit/ConstructsTest.php
@@ -272,6 +272,14 @@ final class ConstructsTest extends Framework\TestCase
                     'Ergebnis\\Classy\\Test\\Fixture\\Classy\\WithinMultipleNamespaces\\Foo\\Foo',
                 ],
             ],
+            'within-namespace-with-single-segment' => [
+                __DIR__ . '/../Fixture/Classy/WithinNamespaceWithSingleSegment/source.php',
+                [
+                    'Ergebnis\\Bar',
+                    'Ergebnis\\Baz',
+                    'Ergebnis\\Foo',
+                ],
+            ],
             'with-methods-named-after-keywords' => [
                 __DIR__ . '/../Fixture/Classy/WithMethodsNamedAfterKeywords/source.php',
                 [


### PR DESCRIPTION
This pull request

* [x] asserts that a class name is determined within a namespace with a single segment
* [x] properly determines a classy name within a namespace with single segment

Fixes #326.