### PR TITLE
Fix: Use methods instead of deprecated magic properties

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -19,11 +19,17 @@
     </MissingConstructor>
   </file>
   <file src="test/Unit/ConstructTest.php">
+    <MixedArgument occurrences="1">
+      <code>$faker-&gt;fileExtension()</code>
+    </MixedArgument>
     <RedundantCondition occurrences="2">
       <code>assertIsArray</code>
       <code>assertIsArray</code>
     </RedundantCondition>
     <TooManyArguments occurrences="1"/>
+    <UndefinedMagicMethod occurrences="1">
+      <code>fileExtension</code>
+    </UndefinedMagicMethod>
   </file>
   <file src="test/Unit/ConstructsTest.php">
     <MixedInferredReturnType occurrences="4">

--- a/test/Unit/ConstructTest.php
+++ b/test/Unit/ConstructTest.php
@@ -28,7 +28,7 @@ final class ConstructTest extends Framework\TestCase
 
     public function testFromNameReturnsConstruct(): void
     {
-        $name = self::faker()->word;
+        $name = self::faker()->word();
 
         $construct = Construct::fromName($name);
 
@@ -38,7 +38,7 @@ final class ConstructTest extends Framework\TestCase
 
     public function testDefaults(): void
     {
-        $construct = Construct::fromName(self::faker()->word);
+        $construct = Construct::fromName(self::faker()->word());
 
         self::assertIsArray($construct->fileNames());
         self::assertCount(0, $construct->fileNames());
@@ -46,7 +46,7 @@ final class ConstructTest extends Framework\TestCase
 
     public function testToStringReturnsName(): void
     {
-        $name = self::faker()->word;
+        $name = self::faker()->word();
 
         $construct = Construct::fromName($name);
 
@@ -57,13 +57,13 @@ final class ConstructTest extends Framework\TestCase
     {
         $faker = self::faker();
 
-        $name = $faker->word;
+        $name = $faker->word();
 
         $fileNames = \array_map(static function () use ($faker): string {
             return \sprintf(
                 '%s.%s',
-                $faker->word,
-                $faker->fileExtension
+                $faker->word(),
+                $faker->fileExtension()
             );
         }, \array_fill(0, 5, null));
 

--- a/test/Unit/Exception/DirectoryDoesNotExistTest.php
+++ b/test/Unit/Exception/DirectoryDoesNotExistTest.php
@@ -29,7 +29,7 @@ final class DirectoryDoesNotExistTest extends Framework\TestCase
 
     public function testFromDirectoryReturnsException(): void
     {
-        $directory = self::faker()->sentence;
+        $directory = self::faker()->sentence();
 
         $exception = DirectoryDoesNotExist::fromDirectory($directory);
 


### PR DESCRIPTION
This pull request

- [x] uses methods instead of deprecated magic properties