### PR TITLE
Fix: Use `range()`

### DIFF
--- a/test/Unit/ConstructTest.php
+++ b/test/Unit/ConstructTest.php
@@ -65,7 +65,7 @@ final class ConstructTest extends Framework\TestCase
                 $faker->word(),
                 $faker->fileExtension()
             );
-        }, \array_fill(0, 5, null));
+        }, \range(0, 5));
 
         $construct = Construct::fromName($name);
 


### PR DESCRIPTION
This pull request

- [x] uses `range()` instead of `array_fill()`