### PR TITLE
Fix: Allow composer plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,8 @@
   "config": {
     "allow-plugins": {
       "composer/package-versions-deprecated": true,
-      "ergebnis/composer-normalize": true
+      "ergebnis/composer-normalize": true,
+      "infection/extension-installer": true
     },
     "platform": {
       "php": "7.4.26"


### PR DESCRIPTION
This pull request

- [x] allows `infection/extension-installer` to run as composer plugin