### PR TITLE
Fix: Configure `infection/infection` via configuration file only

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -9,8 +9,6 @@ on: # yamllint disable-line rule:truthy
       - "main"
 
 env:
-  MIN_COVERED_MSI: 85
-  MIN_MSI: 82
   PHP_EXTENSIONS: "mbstring, tokenizer"
 
 jobs:
@@ -211,7 +209,7 @@ jobs:
           dependencies: "${{ matrix.dependencies }}"
 
       - name: "Run mutation tests with Xdebug and infection/infection"
-        run: "vendor/bin/infection --ignore-msi-with-no-mutations --min-covered-msi=${{ env.MIN_COVERED_MSI }} --min-msi=${{ env.MIN_MSI }}"
+        run: "vendor/bin/infection --configuration=infection.json"
 
   static-code-analysis:
     name: "Static Code Analysis"

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,3 @@
-MIN_COVERED_MSI:=85
-MIN_MSI:=82
-
 .PHONY: it
 it: coding-standards static-code-analysis tests ## Runs the coding-standards, static-code-analysis, and tests targets
 
@@ -27,7 +24,7 @@ help: ## Displays this list of targets with descriptions
 .PHONY: mutation-tests
 mutation-tests: vendor ## Runs mutation tests with infection/infection
 	mkdir -p .build/infection
-	vendor/bin/infection --ignore-msi-with-no-mutations --min-covered-msi=${MIN_COVERED_MSI} --min-msi=${MIN_MSI}
+	vendor/bin/infection --configuration=infection.json
 
 .PHONY: static-code-analysis
 static-code-analysis: vendor ## Runs a static code analysis vimeo/psalm

--- a/infection.json
+++ b/infection.json
@@ -1,7 +1,10 @@
 {
+  "ignoreMsiWithNoMutations": true,
   "logs": {
     "text": ".build/infection/infection-log.txt"
   },
+  "minCoveredMsi": 86,
+  "minMsi": 83,
   "phpUnit": {
     "configDir": "test\/Unit"
   },


### PR DESCRIPTION
This pull request

- [x] configures `infection/infection` via configuration file only