### PR TITLE
Fix: Do not configure `platform`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,9 +61,6 @@
     "audit": {
       "abandoned": "report"
     },
-    "platform": {
-      "php": "8.1.20"
-    },
     "preferred-install": "dist",
     "sort-packages": true
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "14edd19f6e28b2c201b91241e86dff37",
+    "content-hash": "507d711f97e4bde0a507aecd32af329c",
     "packages": [],
     "packages-dev": [
         {
@@ -6203,8 +6203,5 @@
         "ext-tokenizer": "*"
     },
     "platform-dev": [],
-    "platform-overrides": {
-        "php": "8.1.20"
-    },
     "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
This pull request

- [x] stops configuring the [`platform`](https://getcomposer.org/doc/06-config.md#platform) in `composer.json`

Follows https://github.com/ergebnis/php-package-template/pull/1376.