### PR TITLE
Fix: Use `list` in DocBlocks

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="5.24.0@462c80e31c34e58cc4f750c656be3927e80e550e">
   <file src="src/Constructs.php">
-    <MixedArgumentTypeCoercion>
+    <ArgumentTypeCoercion>
       <code><![CDATA[$constructsWithMultipleDefinitions]]></code>
+    </ArgumentTypeCoercion>
+    <MixedArgumentTypeCoercion>
       <code><![CDATA[\usort($constructs, static function (Construct $a, Construct $b): int {
             return \strcmp(
                 $a->name(),
@@ -20,7 +22,7 @@
     </MixedMethodCall>
     <MixedReturnTypeCoercion>
       <code><![CDATA[\array_values($constructs)]]></code>
-      <code><![CDATA[array<int, Construct>]]></code>
+      <code><![CDATA[list<Construct>]]></code>
     </MixedReturnTypeCoercion>
     <RedundantFunctionCall>
       <code><![CDATA[\array_values]]></code>

--- a/src/Construct.php
+++ b/src/Construct.php
@@ -16,7 +16,7 @@ namespace Ergebnis\Classy;
 final class Construct
 {
     /**
-     * @var array<int, string>
+     * @var list<string>
      */
     private array $fileNames = [];
 
@@ -51,9 +51,9 @@ final class Construct
     }
 
     /**
-     * Returns an array of file names in which the construct is defined.
+     * Returns a list of file names in which the construct is defined.
      *
-     * @return array<int, string>
+     * @return list<string>
      */
     public function fileNames(): array
     {

--- a/src/Constructs.php
+++ b/src/Constructs.php
@@ -16,11 +16,11 @@ namespace Ergebnis\Classy;
 final class Constructs
 {
     /**
-     * Returns an array of names of classy constructs (classes, interfaces, traits) found in source.
+     * Returns a list of constructs defined in source code.
      *
      * @throws Exception\ParseError
      *
-     * @return array<int, Construct>
+     * @return list<Construct>
      */
     public static function fromSource(string $source): array
     {
@@ -111,12 +111,12 @@ final class Constructs
     }
 
     /**
-     * Returns an array of constructs defined in a directory.
+     * Returns a list of constructs defined in a directory.
      *
      * @throws Exception\DirectoryDoesNotExist
      * @throws Exception\MultipleDefinitionsFound
      *
-     * @return array<int, Construct>
+     * @return list<Construct>
      */
     public static function fromDirectory(string $directory): array
     {

--- a/src/Exception/MultipleDefinitionsFound.php
+++ b/src/Exception/MultipleDefinitionsFound.php
@@ -18,14 +18,14 @@ use Ergebnis\Classy\Construct;
 final class MultipleDefinitionsFound extends \RuntimeException implements ExceptionInterface
 {
     /**
-     * @var array<int, Construct>
+     * @var list<Construct>
      */
     private array $constructs = [];
 
     /**
      * Returns a new exception from constructs.
      *
-     * @param array<int, Construct> $constructs
+     * @param list<Construct> $constructs
      */
     public static function fromConstructs(array $constructs): self
     {
@@ -46,9 +46,9 @@ final class MultipleDefinitionsFound extends \RuntimeException implements Except
     }
 
     /**
-     * Returns an array of constructs.
+     * Returns a list of constructs.
      *
-     * @return array<int, Construct>
+     * @return list<Construct>
      */
     public function constructs(): array
     {

--- a/test/Unit/ConstructsTest.php
+++ b/test/Unit/ConstructsTest.php
@@ -228,7 +228,7 @@ final class ConstructsTest extends Framework\TestCase
     }
 
     /**
-     * @return array<int, Test\Util\Scenario>
+     * @return list<Test\Util\Scenario>
      */
     private static function scenariosWithClassyConstructs(): array
     {

--- a/test/Util/Scenario.php
+++ b/test/Util/Scenario.php
@@ -23,7 +23,7 @@ final class Scenario
     private readonly string $fileContent;
 
     /**
-     * @var array<int, Classy\Construct>
+     * @var list<Classy\Construct>
      */
     private readonly array $constructs;
 
@@ -114,7 +114,7 @@ final class Scenario
     }
 
     /**
-     * @return array<int, Classy\Construct>
+     * @return list<Classy\Construct>
      */
     public function constructsSortedByName(): array
     {


### PR DESCRIPTION
This pull request

- [x] uses `list` in DocBlocks